### PR TITLE
Hasura webhook for request authorization

### DIFF
--- a/src/integration-test/kotlin/fi/hsl/jore4/auth/SessionRequestBuilder.kt
+++ b/src/integration-test/kotlin/fi/hsl/jore4/auth/SessionRequestBuilder.kt
@@ -1,0 +1,15 @@
+package fi.hsl.jore4.auth
+
+import org.springframework.mock.web.MockHttpSession
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+
+open class SessionRequestBuilder(
+    private val apiPathPrefix: String
+) {
+    protected fun getWithSession(path: String, session: MockHttpSession? = null): MockHttpServletRequestBuilder {
+        val requestBuilder = MockMvcRequestBuilders.get("$apiPathPrefix$path")
+
+        return session?.let { requestBuilder.session(it) } ?: requestBuilder
+    }
+}

--- a/src/integration-test/kotlin/fi/hsl/jore4/auth/apipublic/v1/HasuraApiControllerTest.kt
+++ b/src/integration-test/kotlin/fi/hsl/jore4/auth/apipublic/v1/HasuraApiControllerTest.kt
@@ -1,0 +1,143 @@
+package fi.hsl.jore4.auth.apipublic.v1
+
+import com.nimbusds.oauth2.sdk.token.BearerAccessToken
+import com.nimbusds.oauth2.sdk.token.RefreshToken
+import fi.hsl.jore4.auth.Constants
+import fi.hsl.jore4.auth.IntegrationTestContext
+import fi.hsl.jore4.auth.MockOIDCProvider
+import fi.hsl.jore4.auth.TestTags
+import fi.hsl.jore4.auth.hasura.HasuraAuthService
+import fi.hsl.jore4.auth.oidc.SessionKeys
+import fi.hsl.jore4.auth.oidc.UserTokenSet
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.mock.web.MockHttpSession
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@ExtendWith(SpringExtension::class)
+@SpringBootTest(classes = [IntegrationTestContext::class])
+@AutoConfigureMockMvc
+@Tag(TestTags.INTEGRATION_TEST)
+class HasuraApiControllerTest(
+    @Autowired private val mockMvc: MockMvc
+) {
+    private val requestBuilder = HasuraApiRequestBuilder(mockMvc, Constants.API_PATH_PREFIX)
+
+    private val accessToken = MockOIDCProvider.createJwtAccessToken()
+    private val roUserInfoContent = MockOIDCProvider.createUserInfoResponseContent(
+        Constants.RO_USER_SUB, Constants.RO_USER_FIRST_NAME, Constants.RO_USER_LAST_NAME, Constants.RO_USER_FULL_NAME,
+        Pair(Constants.RO_USER_EXT_PERMISSION_ID, Constants.RO_USER_EXT_PERMISSION_EXT_ID)
+    )
+    private val rwUserInfoContent = MockOIDCProvider.createUserInfoResponseContent(
+        Constants.RW_USER_SUB, Constants.RW_USER_FIRST_NAME, Constants.RW_USER_LAST_NAME, Constants.RW_USER_FULL_NAME,
+        Pair(Constants.RW_USER_EXT_PERMISSION_1_ID, Constants.RW_USER_EXT_PERMISSION_1_EXT_ID),
+        Pair(Constants.RW_USER_EXT_PERMISSION_2_ID, Constants.RW_USER_EXT_PERMISSION_2_EXT_ID)
+    )
+
+    @BeforeEach
+    fun setup() {
+        MockOIDCProvider.reset()
+    }
+
+    @Nested
+    @DisplayName("Should respond 401 Unauthorized")
+    inner class ShouldRespondUnauthorized {
+
+        @Test
+        @DisplayName("If no session is present")
+        fun ifNoSessionIsPresent() {
+            with(MockOIDCProvider) {
+                returnUserInfo(roUserInfoContent, accessToken)
+            }
+
+            requestBuilder.webhook(session = null, requestedRole = Constants.RO_USER_EXT_PERMISSION_EXT_ID)
+                .andExpect(status().isUnauthorized)
+                .andExpect(content().string(""))
+        }
+
+        @Test
+        @DisplayName("If no access token is present")
+        fun ifNoAccessTokenIsPresent() {
+            with(MockOIDCProvider) {
+                returnUserInfo(roUserInfoContent, accessToken)
+            }
+
+            requestBuilder.webhook(MockHttpSession(), Constants.RO_USER_EXT_PERMISSION_EXT_ID)
+                .andExpect(status().isUnauthorized)
+                .andExpect(content().string(""))
+        }
+
+        @Test
+        @DisplayName("If user does not have requested permission")
+        fun ifUserDoesNotHaveRequestedPermission() {
+            with(MockOIDCProvider) {
+                returnUserInfo(roUserInfoContent, accessToken)
+            }
+
+            val session = MockHttpSession()
+            session.setAttribute(
+                SessionKeys.USER_TOKEN_SET_KEY,
+                UserTokenSet(BearerAccessToken(accessToken), RefreshToken(Constants.OIDC_REFRESH_TOKEN))
+            )
+
+            requestBuilder.webhook(session, "userDoesNotHaveThisPermission")
+                .andExpect(status().isUnauthorized)
+                .andExpect(content().string(""))
+        }
+    }
+
+    @Nested
+    @DisplayName("Should reply with the Hasura session")
+    inner class ShouldWithHasuraSession {
+        @Test
+        @DisplayName("If user has requested permission as only permission")
+        fun ifUserHasRequestedPermissionAsOnlyPermission() {
+            with(MockOIDCProvider) {
+                returnUserInfo(roUserInfoContent, accessToken)
+            }
+
+            val session = MockHttpSession()
+            session.setAttribute(
+                SessionKeys.USER_TOKEN_SET_KEY,
+                UserTokenSet(BearerAccessToken(accessToken), RefreshToken(Constants.OIDC_REFRESH_TOKEN))
+            )
+
+            requestBuilder.webhook(session, Constants.RO_USER_EXT_PERMISSION_EXT_ID)
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.X-Hasura-User-Id").value(Constants.RO_USER_SUB))
+                .andExpect(jsonPath("$.X-Hasura-Role").value(Constants.RO_USER_EXT_PERMISSION_EXT_ID))
+                .andExpect(jsonPath("$.Cache-Control").value(HasuraAuthService.CACHE_CONTROL_SPEC))
+        }
+
+        @Test
+        @DisplayName("If user has requested permission as one of more permissions")
+        fun ifUserHasRequestedPermissionAsOneOfMorePermissions() {
+            with(MockOIDCProvider) {
+                returnUserInfo(rwUserInfoContent, accessToken)
+            }
+
+            val session = MockHttpSession()
+            session.setAttribute(
+                SessionKeys.USER_TOKEN_SET_KEY,
+                UserTokenSet(BearerAccessToken(accessToken), RefreshToken(Constants.OIDC_REFRESH_TOKEN))
+            )
+
+            requestBuilder.webhook(session, Constants.RW_USER_EXT_PERMISSION_2_EXT_ID)
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.X-Hasura-User-Id").value(Constants.RW_USER_SUB))
+                .andExpect(jsonPath("$.X-Hasura-Role").value(Constants.RW_USER_EXT_PERMISSION_2_EXT_ID))
+                .andExpect(jsonPath("$.Cache-Control").value(HasuraAuthService.CACHE_CONTROL_SPEC))
+        }
+    }
+}

--- a/src/integration-test/kotlin/fi/hsl/jore4/auth/apipublic/v1/HasuraApiRequestBuilder.kt
+++ b/src/integration-test/kotlin/fi/hsl/jore4/auth/apipublic/v1/HasuraApiRequestBuilder.kt
@@ -1,0 +1,23 @@
+package fi.hsl.jore4.auth.apipublic.v1
+
+import fi.hsl.jore4.auth.SessionRequestBuilder
+import fi.hsl.jore4.auth.hasura.HasuraAuthService
+import org.springframework.mock.web.MockHttpSession
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.ResultActions
+
+class HasuraApiRequestBuilder(
+    private val mockMvc: MockMvc,
+    apiPathPrefix: String
+) : SessionRequestBuilder(apiPathPrefix) {
+
+    fun webhook(session: MockHttpSession? = null, requestedRole: String? = null): ResultActions {
+        var requestBuilder = getWithSession("/public/v1/hasura/webhook", session)
+
+        if (requestedRole != null) {
+            requestBuilder = requestBuilder.header(HasuraAuthService.REQUESTED_ROLE_HEADER, requestedRole)
+        }
+
+        return mockMvc.perform(requestBuilder)
+    }
+}

--- a/src/integration-test/kotlin/fi/hsl/jore4/auth/apipublic/v1/OIDCApiRequestBuilder.kt
+++ b/src/integration-test/kotlin/fi/hsl/jore4/auth/apipublic/v1/OIDCApiRequestBuilder.kt
@@ -1,16 +1,16 @@
 package fi.hsl.jore4.auth.apipublic.v1
 
+import fi.hsl.jore4.auth.SessionRequestBuilder
 import fi.hsl.jore4.auth.apipublic.v1.OIDCCodeExchangeApiController.Companion.EXCHANGE_ENDPOINT_PATH_SUFFIX
 import org.springframework.mock.web.MockHttpSession
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.ResultActions
-import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 
 class OIDCApiRequestBuilder(
     private val mockMvc: MockMvc,
-    private val apiPathPrefix: String
-) {
+    apiPathPrefix: String
+) : SessionRequestBuilder(apiPathPrefix) {
+
     fun login(session: MockHttpSession? = null): ResultActions =
         mockMvc.perform(getWithSession("/public/v1/login", session))
 
@@ -26,10 +26,4 @@ class OIDCApiRequestBuilder(
 
     fun getUserInfo(session: MockHttpSession? = null): ResultActions =
         mockMvc.perform(getWithSession("/public/v1/userInfo", session))
-
-    private fun getWithSession(path: String, session: MockHttpSession? = null): MockHttpServletRequestBuilder {
-        val requestBuilder = MockMvcRequestBuilders.get("$apiPathPrefix$path")
-
-        return session?.let { requestBuilder.session(it) } ?: requestBuilder
-    }
 }

--- a/src/main/kotlin/fi/hsl/jore4/auth/apipublic/v1/HasuraApiController.kt
+++ b/src/main/kotlin/fi/hsl/jore4/auth/apipublic/v1/HasuraApiController.kt
@@ -1,0 +1,34 @@
+package fi.hsl.jore4.auth.apipublic.v1
+
+import fi.hsl.jore4.auth.apipublic.v1.model.SessionApiDTO
+import fi.hsl.jore4.auth.hasura.HasuraAuthService
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import javax.servlet.http.HttpServletRequest
+
+/**
+ * Hasura-specific endpoints.
+ */
+@RestController
+@RequestMapping("\${api.path.prefix}/public/v1")
+open class HasuraApiController(
+    private val hasuraAuthService: HasuraAuthService,
+    private val request: HttpServletRequest
+) : HasuraApi {
+
+    companion object {
+        val LOGGER: Logger = LoggerFactory.getLogger(HasuraApiController::class.java)
+    }
+
+    override fun webhook(): ResponseEntity<SessionApiDTO> {
+        LOGGER.info("Fetching Hasura session")
+
+        val hasuraSession = hasuraAuthService.getSession(request)
+        LOGGER.info("Fetched Hasura session: {}", hasuraSession)
+
+        return ResponseEntity.ok(hasuraSession)
+    }
+}

--- a/src/main/kotlin/fi/hsl/jore4/auth/hasura/HasuraAuthService.kt
+++ b/src/main/kotlin/fi/hsl/jore4/auth/hasura/HasuraAuthService.kt
@@ -1,0 +1,61 @@
+package fi.hsl.jore4.auth.hasura
+
+import fi.hsl.jore4.auth.apipublic.v1.model.SessionApiDTO
+import fi.hsl.jore4.auth.userInfo.UserInfoService
+import fi.hsl.jore4.auth.web.UnauthorizedException
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import javax.servlet.http.HttpServletRequest
+
+/**
+ * Hasura authorization.
+ */
+@Service
+open class HasuraAuthService(
+    private val userInfoService: UserInfoService
+) {
+    companion object {
+        private val LOGGER: Logger = LoggerFactory.getLogger(HasuraAuthService::class.java)
+
+        const val REQUESTED_ROLE_HEADER = "x-hasura-role"
+
+        private const val SESSION_EXPIRATION_TIME_SEC = 30  // Our response is valid for this time
+        const val CACHE_CONTROL_SPEC = "max-age=$SESSION_EXPIRATION_TIME_SEC"
+    }
+
+    /**
+     * Retrieve the Hasura session information for the given request and the logged in user if the request is
+     * authorized.
+     *
+     * The request will be authorized if the specified value of the header {@code REQUESTED_ROLE_HEADER}
+     * is found in the currently logged in user's user info permissions.
+     *
+     * @returns the Hasura session information if the request is authorized.
+     *
+     * @throws UnauthorizedException if the request was not authorized.
+     */
+    open fun getSession(request: HttpServletRequest): SessionApiDTO {
+        LOGGER.debug("Fetching Hasura session data")
+
+        val requestedRole = request.getHeader(REQUESTED_ROLE_HEADER)
+            ?: throw UnauthorizedException("Requested role not specified in request headers")
+
+        val userInfo = userInfoService.getUserInfo()
+        LOGGER.debug("Got user info {}", userInfo)
+
+        if (!userInfo.permissions.contains(requestedRole)) {
+            throw UnauthorizedException("Requested role not present in user permissions")
+        }
+
+        // The requested role was found among the user permissions, so grant the role in the response
+        val session = SessionApiDTO().apply {
+            xHasuraUserId(userInfo.id)
+            xHasuraRole(requestedRole)
+            cacheControl = CACHE_CONTROL_SPEC
+        }
+
+        LOGGER.debug("Fetched Hasura session data {}", session)
+        return session
+    }
+}

--- a/src/main/openapi/api.yaml
+++ b/src/main/openapi/api.yaml
@@ -13,3 +13,5 @@ paths:
     $ref: './authentication.yaml#/paths/login'
   /logout:
     $ref: './authentication.yaml#/paths/logout'
+  /hasura/webhook:
+    $ref: './hasura.yaml#/paths/webhook'

--- a/src/main/openapi/hasura.yaml
+++ b/src/main/openapi/hasura.yaml
@@ -1,0 +1,23 @@
+openapi: "3.0.0"
+
+paths:
+  webhook:
+    get:
+      tags:
+        - hasura
+      summary: Hasura authorization webhook
+      description: >
+        Returns the hasura session data of the currently logged in user for the request
+        to be authorized or 401 Unauthorized of the request was not authorized.
+      operationId: webhook
+      produces:
+        - application/json
+      responses:
+        200:
+          description: Returns the requested hasura session data.
+          content:
+            application/json:
+              schema:
+                $ref: './types/hasura.yaml#/definitions/session'
+        401:
+          description: The request was not authorized.

--- a/src/main/openapi/types/hasura.yaml
+++ b/src/main/openapi/types/hasura.yaml
@@ -1,0 +1,19 @@
+openapi: "3.0.0"
+
+definitions:
+  session:
+    description: >
+      Contains the hasura session data of the logged in user for a certain request as defined
+      by the Hasura webhook specification
+      (https://hasura.io/docs/latest/graphql/core/auth/authentication/webhook.html).
+    type: object
+    properties:
+      X-Hasura-User-Id:
+        type: string
+        description: The unique id of the user whose request to authorized.
+      X-Hasura-Role:
+        type: string
+        description: The role granted to the user for the authorized request.
+      Cache-Control:
+        type: string
+        description: The cache-control options for this session information.


### PR DESCRIPTION
The webhook will authorize a request if the value of the `x-hasura-role`
header is found in the currently logged in user's user info external
permissions. A 200 Ok response will be sent in this case together with
the Hasura session data.

In all other cases the request will not be authorized and a 401
Unauthorized response will be sent.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-auth/8)
<!-- Reviewable:end -->
