### PR TITLE
Code cleanup: Remove unneeded variable property declarations

### DIFF
--- a/src/main/kotlin/fi/hsl/jore4/auth/oidc/UserTokenSet.kt
+++ b/src/main/kotlin/fi/hsl/jore4/auth/oidc/UserTokenSet.kt
@@ -17,18 +17,13 @@ import javax.naming.AuthenticationException
  * Holds the user's access and refresh tokens and refreshes them.
  */
 class UserTokenSet(
-    accessToken: AccessToken,
-    refreshToken: RefreshToken
+    val accessToken: AccessToken,
+    val refreshToken: RefreshToken
 ) : Serializable {
 
     companion object {
         private val LOGGER = LoggerFactory.getLogger(UserTokenSet::class.java)
     }
-
-    var accessToken: AccessToken = accessToken
-        private set
-    var refreshToken: RefreshToken = refreshToken
-        private set
 
     /**
      * Refresh the access and refresh tokens.


### PR DESCRIPTION
The declarations are a relict from the first implementation of the
UserTokenSet, which re-set the token values upon refresh. They are not
needed anymore, because the new implementation uses an immutable style
approach for refreshing tokens.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-auth/15)
<!-- Reviewable:end -->
