### PR TITLE
Switch to Temurin JRE v17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,5 +15,20 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: "17"
+          java-package: jdk
+          architecture: x64
+          distribution: temurin
+
+      - name: Cache Maven packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+
       - name: Run tests
         run: mvn clean verify -Pall-tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # builder docker image
-FROM maven:3-openjdk-11 AS builder
+FROM maven:3-eclipse-temurin-17 AS builder
 
 # set up workdir
 WORKDIR /build
@@ -14,7 +14,7 @@ COPY ./profiles/prod /build/profiles/prod
 RUN mvn clean package spring-boot:repackage -Pprod
 
 # distributed docker image
-FROM openjdk:11-jre
+FROM eclipse-temurin:17.0.8_7-jre
 
 # expose server port
 EXPOSE 8080

--- a/pom.xml
+++ b/pom.xml
@@ -225,7 +225,7 @@
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <groupId>org.apache.maven.plugins</groupId>
                 <configuration>
-                    <argLine>-Xmx1024m -XX:MaxPermSize=256m</argLine>
+                    <argLine>-Xmx1024m</argLine>
                     <disableXmlReport>false</disableXmlReport>
                     <groups>integrationTest</groups>
                     <includes>


### PR DESCRIPTION
Standardise on Adoptium Temurin Eclipse OpenJDK. This is the same JRE as what is used in `jore4-map-matching` and `jore4-hastus`.

Update JRE from 11 (LTS) to 17 (LTS) to enable migration to Spring Boot 3 in the future.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-auth/26)
<!-- Reviewable:end -->
