### PR TITLE
Update Github Workflows

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -21,7 +21,7 @@ jobs:
       - run_unit_tests
       - check_code_formatting
     name: Build & Push docker image to dockerhub
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -66,6 +66,9 @@ jobs:
       - check_code_formatting
       - push_to_registry
     name: Run e2e tests
+    # These must run on ubuntu 22.04 or older.
+    # The MS SQL server used by jore4-jore3-importer,
+    # does not run on Linux kernels newer than 6.6.x.
     runs-on: ubuntu-22.04
     steps:
       - name: Extract metadata to env variables

--- a/.github/workflows/check-renovatebot-config.yml
+++ b/.github/workflows/check-renovatebot-config.yml
@@ -12,6 +12,6 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Validate
-        uses: suzuki-shunsuke/github-action-renovate-config-validator@v1.0.1
+        uses: suzuki-shunsuke/github-action-renovate-config-validator@v1.1.0
         with:
           config_file_path: .github/renovate.json5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   tests:
     name: Run auth backend tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout code
@@ -20,13 +20,7 @@ jobs:
           java-package: jdk
           architecture: x64
           distribution: temurin
-
-      - name: Cache Maven packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+          cahce: maven
 
       - name: Run tests
         run: mvn clean verify -Pall-tests

--- a/.github/workflows/ktlint.yml
+++ b/.github/workflows/ktlint.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   spotless:
     name: Check code is formatted with ktlint
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout code
@@ -19,13 +19,7 @@ jobs:
           java-package: jdk
           architecture: x64
           distribution: temurin
-
-      - name: Cache Maven packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+          cahce: maven
 
       - name: Run ktlint Check
         run: mvn ktlint:check


### PR DESCRIPTION
* Run on Ubuntu 24.04 or 22.04 for tasks requiring e2e env
* Use actions/setup-java build-in cache
* Update suzuki-shunsuke/github-action-renovate-config-validator to  1.1.0

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-auth/41)
<!-- Reviewable:end -->
